### PR TITLE
Update breakpoint to prevent content from clipping

### DIFF
--- a/src/components/setup/ActionCardDistribution.vue
+++ b/src/components/setup/ActionCardDistribution.vue
@@ -2,10 +2,10 @@
   <h3 class="mt-4 mb-3">{{t('setup.actionCardDistribution.title')}}</h3>
 
   <div class="row mt-3">
-    <div class="col-5 col-md-3">
+    <div class="col-sm-5 col-md-3">
       <label for="playerCount" class="form-label">{{t('setup.actionCardDistribution.schema')}}</label>
     </div>
-    <div class="col-5 col-md-3">
+    <div class="col-sm-5 col-md-3">
       <select class="form-select" v-model="selectedSchema">
         <option v-for="(schema,index) in schemas" :key="index" :value="schema+''">{{schema}}</option>
       </select>

--- a/src/components/setup/DifficultyLevel.vue
+++ b/src/components/setup/DifficultyLevel.vue
@@ -2,19 +2,19 @@
   <h3 class="mt-4 mb-3">{{t('setup.difficultyLevel.title')}}</h3>
 
   <div class="row">
-    <div class="col-1 text-end">
+    <div class="col-2 col-md-1 text-end">
       <label for="difficultyLevel" class="form-label">{{t('setup.difficultyLevel.easy')}}</label>
     </div>
     <div class="col-8 col-md-4">
       <input type="range" class="form-range" min="1" max="6" id="difficultyLevel"
           :value="$store.state.setup.difficultyLevel" @input="updateDifficultyLevel($event)">
     </div>
-    <div class="col-1">
+    <div class="col-2 col-md-1">
       <label for="difficultyLevel" class="form-label">{{t('setup.difficultyLevel.hard')}}</label>
     </div>
   </div>
   <div class="row">
-    <div class="offset-1 col-8 col-md-4 text-muted small">
+    <div class="offset-2 offset-md-1 col-8 col-md-4 text-muted small">
       {{t(`difficultyLevel.${$store.state.setup.difficultyLevel}`)}}
     </div>
   </div>  

--- a/src/components/setup/PickZooMap.vue
+++ b/src/components/setup/PickZooMap.vue
@@ -2,13 +2,13 @@
   <h3 class="mt-4 mb-3">{{t('setup.pickZooMap.title')}}</h3>
 
   <div class="row mt-3">
-    <div class="col-5 col-md-3">
+    <div class="col-sm-5 col-md-3">
       <label for="playerCount" class="form-label">{{t('setup.pickZooMap.title')}}</label>
       <button type="button" class="upgrade btn btn-outline-secondary btn-sm ms-2" @click="pickRandom">
         {{t('setup.pickZooMap.pickRandom')}}
       </button><br/>
     </div>
-    <div class="col-5 col-md-3">
+    <div class="col-sm-5 col-md-3 mt-3 mt-0-sm">
       <select class="form-select" v-model="selectedMap">
         <option :value="''">{{t('setup.pickZooMap.pleaseSelect')}}</option>
         <option :value="'A'">{{t('setup.pickZooMap.mapA')}}</option>

--- a/src/components/setup/PickZooMap.vue
+++ b/src/components/setup/PickZooMap.vue
@@ -8,7 +8,7 @@
         {{t('setup.pickZooMap.pickRandom')}}
       </button><br/>
     </div>
-    <div class="col-sm-5 col-md-3 mt-3 mt-0-sm">
+    <div class="col-sm-5 col-md-3 mt-3 mt-sm-0">
       <select class="form-select" v-model="selectedMap">
         <option :value="''">{{t('setup.pickZooMap.pleaseSelect')}}</option>
         <option :value="'A'">{{t('setup.pickZooMap.mapA')}}</option>

--- a/src/components/setup/PlayersSetup.vue
+++ b/src/components/setup/PlayersSetup.vue
@@ -5,7 +5,7 @@
     <div class="col-5 col-md-3">
       <label for="playerCount" class="form-label">{{t('setup.players.playerCount')}}</label>
     </div>
-    <div class="col-5 col-md-3">
+    <div class="col-6 col-sm-5 col-md-3">
       <select class="form-select" id="playerCount" v-model="playerCount">
         <option v-for="i in maxPlayerCount" :key="i" :value="i">{{t('setup.players.playerCountItem', {count:i}, i)}}</option>
       </select>
@@ -24,7 +24,7 @@
     <div class="col-5 col-md-3">
       <label for="botCount" class="form-label">{{t('setup.players.botCount')}}</label>
     </div>
-    <div class="col-5 col-md-3">
+    <div class="col-6 col-sm-5 col-md-3">
       <select class="form-select" id="botCount" v-model="botCount">
         <option v-for="i in maxBotCount" :key="i" :value="i">{{t('setup.players.botCountItem', {count:i}, i)}}</option>
       </select>


### PR DESCRIPTION
First off, thanks for creating this helper app! Haven't had a chance to play against ARNO yet but have poked around in the app.

## Details

One thing I noticed is that on smaller screens (specifically mobile devices) some of the content get clipped on the setup page.

Updating the column/breakpoints fixes this at the cost of marginally most vertical screen real estate on mobile.

| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/14844346/208150323-65bb9b80-2148-44a6-b29f-cd1e280157b6.png)      | ![image](https://user-images.githubusercontent.com/14844346/208151297-b23edd01-7c97-4fa6-8010-96525dbd4ba6.png)       |

## Gotcha

One gotcha that's worth pointing out and usually the case with responsive design is there is an time when the content takes up more width that it needs (see example 1/2 below) until it hits the larger breakpoint (see example 3 below).

| Example 1 | Example 2 | Example 3 |
| ----------- | ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/14844346/208151990-45915285-49b5-468a-bb74-7364fad7d36f.png) | ![image](https://user-images.githubusercontent.com/14844346/208152022-3fb05b3f-c2bd-4a6a-8bc7-e1a4bf07c118.png) | ![image](https://user-images.githubusercontent.com/14844346/208152050-f4ff4e68-3f65-4a77-9602-ea7262cf0309.png)